### PR TITLE
fix: s3 관련 api 로직 개선

### DIFF
--- a/app/(board)/post/page.tsx
+++ b/app/(board)/post/page.tsx
@@ -17,6 +17,7 @@ import { useState, ChangeEvent, useEffect, useMemo, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { SelectCategoryModal } from "./SelectCategoryModal";
 import { fetchAPI } from "@/lib/functions";
+import { uploadBoard } from "@/lib/functions/multipartApi";
 
 const buildQueryParams = (
   params: Record<
@@ -147,9 +148,10 @@ const PostPage = () => {
         throw new Error("이미지 또는 PDF 파일을 1개 이상 업로드해주세요.");
       }
 
-      const uploadedKeys = await uploadBoardFiles(imageFiles, pdfFile);
-
       if (isEditMode) {
+        // 수정 모드: 기존 presigned URL 방식 유지 (V2 수정 엔드포인트 미지원)
+        const uploadedKeys = await uploadBoardFiles(imageFiles, pdfFile);
+
         const queryString = buildQueryParams({
           title: trimmedTitle,
           content: trimmedContent,
@@ -161,11 +163,13 @@ const PostPage = () => {
         return;
       }
 
-      await createBoard({
+      // 생성 모드: V2 multipart API (파일 + 데이터 한번에)
+      await uploadBoard({
         title: trimmedTitle,
         content: trimmedContent,
         category: selectedCategory,
-        keys: uploadedKeys,
+        images: imageFiles.length > 0 ? imageFiles : undefined,
+        pdf: pdfFile || undefined,
       });
     },
   });

--- a/app/(board)/upload/page.tsx
+++ b/app/(board)/upload/page.tsx
@@ -15,6 +15,7 @@ import CheckCircle from "@/public/CheckCircle.svg";
 import { QUESTION_FORM_RULES } from "@/constants/formValidation";
 import { useSubjects } from "@/hooks";
 import { fetchAPI } from "@/lib/functions";
+import { uploadMaterial } from "@/lib/functions/multipartApi";
 import { useQuery } from "@tanstack/react-query";
 
 enum Step {
@@ -212,34 +213,43 @@ const UploadPage = () => {
         );
       }
 
-      const existingImageKeys = previewItems
-        .filter(
-          (item: any) => item.source === "remote" && item.type === "image",
-        )
-        .map((item: any) => item.key)
-        .filter(Boolean);
+      if (isEditMode) {
+        // 수정 모드: 기존 presigned URL 방식 유지 (V2 수정 엔드포인트 미지원)
+        const existingImageKeys = previewItems
+          .filter(
+            (item: any) => item.source === "remote" && item.type === "image",
+          )
+          .map((item: any) => item.key)
+          .filter(Boolean);
 
-      const existingPdfKey =
-        previewItems.find(
-          (item: any) => item.source === "remote" && item.type === "pdf",
-        )?.key ?? null;
+        const existingPdfKey =
+          previewItems.find(
+            (item: any) => item.source === "remote" && item.type === "pdf",
+          )?.key ?? null;
 
-      const { imageKeys: newImageKeys, pdfKey: newPdfKey } =
-        await uploadMaterialFiles(imageFiles, pdfFile);
+        const { imageKeys: newImageKeys, pdfKey: newPdfKey } =
+          await uploadMaterialFiles(imageFiles, pdfFile);
 
-      const payload = {
+        const payload = {
+          title: data.title.trim(),
+          content: data.content.trim(),
+          subjectId: Number(data.subjectId),
+          urlKey: [...existingImageKeys, ...newImageKeys],
+          pdfKey: newPdfKey ?? existingPdfKey,
+        };
+
+        await fetchAPI(`/api/materials/${editId}`, "PUT", payload);
+        return;
+      }
+
+      // 생성 모드: V2 multipart API (파일 + 데이터 한번에)
+      await uploadMaterial({
         title: data.title.trim(),
         content: data.content.trim(),
         subjectId: Number(data.subjectId),
-        urlKey: [...existingImageKeys, ...newImageKeys],
-        pdfKey: newPdfKey ?? existingPdfKey,
-      };
-
-      await fetchAPI(
-        isEditMode ? `/api/materials/${editId}` : "/api/materials",
-        isEditMode ? "PUT" : "POST",
-        payload,
-      );
+        files: imageFiles.length > 0 ? imageFiles : undefined,
+        pdf: pdfFile || undefined,
+      });
     },
   });
 

--- a/app/(setting)/editprofile/page.tsx
+++ b/app/(setting)/editprofile/page.tsx
@@ -3,7 +3,6 @@
 import { useAtom } from "jotai";
 import {
   profileImgAtom,
-  idAtom,
   updateProfileAtom,
   nicknameAtom,
 } from "@/store/profile";
@@ -11,16 +10,12 @@ import {
 import { useState, useRef, ChangeEvent } from "react";
 import { CustomHeader, IconInputField } from "@/components/molecules";
 import { ProfileImg, SolidButton, Toast } from "@/components/atoms";
-import { useUpload } from "./_hooks/useUpload";
-import { accessTokenAtom } from "@/store/S3auth";
 import { useRouter } from "next/navigation";
-import { useUpdate } from "./_hooks/useUpdate";
+import { uploadProfile } from "@/lib/functions/multipartApi";
 
 const EditProfile = () => {
   const [serverProfileImg] = useAtom(profileImgAtom);
   const [serverNickname] = useAtom(nicknameAtom);
-  const [userId] = useAtom(idAtom);
-  const [accessToken] = useAtom(accessTokenAtom);
 
   const [tempProfileImg, setTempProfileImg] = useState<string | null>(
     serverProfileImg,
@@ -31,9 +26,6 @@ const EditProfile = () => {
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const router = useRouter();
-
-  const { onUpload } = useUpload();
-  const { onUpdate } = useUpdate();
 
   const handleProfileImgClick = () => fileInputRef.current?.click();
 
@@ -51,46 +43,13 @@ const EditProfile = () => {
       return;
     }
 
-    if (!userId) {
-      alert("유저 ID를 확인할 수 없습니다.");
-      return;
-    }
-
-    if (!accessToken) {
-      alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
-      return;
-    }
-
     try {
-      let keys: string[] = [];
-
-      if (fileInputRef.current?.files?.[0]) {
-        const file = fileInputRef.current.files[0];
-
-        const result = await onUpload({
-          userId,
-          file,
-          type: "profile",
-          access_token: `Bearer ${accessToken}`,
-        });
-
-        if (!result?.success || !result?.key) {
-          throw new Error("이미지 업로드 실패");
-        }
-
-        keys = [result.key];
-      }
-
-      await onUpdate({
-        accessToken,
-        tempNickname: tempNickname.trim(),
-        keys,
-      });
+      const file = fileInputRef.current?.files?.[0];
+      await uploadProfile(tempNickname.trim(), file);
 
       updateProfile({
         nickname: tempNickname.trim(),
         profileImg: tempProfileImg ?? serverProfileImg ?? undefined,
-        keys,
       });
 
       setOpen(true);

--- a/app/api/boards/upload/route.ts
+++ b/app/api/boards/upload/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "@/lib/functions/serverProxyMultipart";
+
+export async function POST(request: NextRequest) {
+  return proxyToBackend(request, "/api/boards/upload", "POST");
+}

--- a/app/api/files/[fileId]/complete/route.ts
+++ b/app/api/files/[fileId]/complete/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "@/lib/functions/serverProxyMultipart";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ fileId: string }> },
+) {
+  const { fileId } = await params;
+  return proxyToBackend(request, `/api/files/${fileId}/complete`, "POST");
+}

--- a/app/api/files/[fileId]/delete/route.ts
+++ b/app/api/files/[fileId]/delete/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "@/lib/functions/serverProxyMultipart";
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ fileId: string }> },
+) {
+  const { fileId } = await params;
+  return proxyToBackend(request, `/api/files/${fileId}/delete`, "DELETE");
+}

--- a/app/api/files/[fileId]/download/route.ts
+++ b/app/api/files/[fileId]/download/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "@/lib/functions/serverProxyMultipart";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ fileId: string }> },
+) {
+  const { fileId } = await params;
+  return proxyToBackend(request, `/api/files/${fileId}/download`, "GET");
+}

--- a/app/api/files/init/route.ts
+++ b/app/api/files/init/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "@/lib/functions/serverProxyMultipart";
+
+export async function POST(request: NextRequest) {
+  return proxyToBackend(request, "/api/files/init", "POST");
+}

--- a/app/api/materials/upload/route.ts
+++ b/app/api/materials/upload/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "@/lib/functions/serverProxyMultipart";
+
+export async function POST(request: NextRequest) {
+  return proxyToBackend(request, "/api/materials/upload", "POST");
+}

--- a/app/api/profile/upload/route.ts
+++ b/app/api/profile/upload/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "@/lib/functions/serverProxyMultipart";
+
+export async function PUT(request: NextRequest) {
+  return proxyToBackend(request, "/api/profile/upload", "PUT");
+}

--- a/lib/functions/index.ts
+++ b/lib/functions/index.ts
@@ -5,3 +5,5 @@ export * from "./buildQueryParams";
 export * from "./jwt";
 export * from "./boardView";
 export * from "./syncViewCount";
+export * from "./multipartApi";
+export * from "./serverProxyMultipart";

--- a/lib/functions/multipartApi.ts
+++ b/lib/functions/multipartApi.ts
@@ -1,0 +1,113 @@
+import { getToken, fetchAPI } from "./fetchData";
+
+// ─── 내부 헬퍼 ───────────────────────────────────────────────
+
+/** FormData + Auth 전송 공통 함수 (Content-Type 미설정 — 브라우저가 boundary 자동 설정) */
+async function fetchWithFormData(
+  url: string,
+  method: string,
+  formData: FormData,
+) {
+  const token = getToken();
+  const headers: Record<string, string> = {};
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const res = await fetch(url, { method, headers, body: formData });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.message || `요청 실패 (${res.status})`);
+  }
+
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+// ─── 프로필 ──────────────────────────────────────────────────
+
+/** 프로필 수정 (닉네임 + 이미지 한번에) */
+export async function uploadProfile(nickname: string, image?: File) {
+  const fd = new FormData();
+  fd.append("nickname", nickname);
+  if (image) fd.append("image", image);
+  return fetchWithFormData("/api/profile/upload", "PUT", fd);
+}
+
+// ─── 게시글 ──────────────────────────────────────────────────
+
+/** 게시글 생성 (multipart) */
+export async function uploadBoard(data: {
+  title: string;
+  content: string;
+  category: string;
+  images?: File[];
+  pdf?: File;
+}) {
+  const fd = new FormData();
+  fd.append("title", data.title);
+  fd.append("content", data.content);
+  fd.append("category", data.category);
+  data.images?.forEach((file) => fd.append("images", file));
+  if (data.pdf) fd.append("pdf", data.pdf);
+  return fetchWithFormData("/api/boards/upload", "POST", fd);
+}
+
+// ─── 학습자료 ────────────────────────────────────────────────
+
+/** 학습자료 생성 (multipart) */
+export async function uploadMaterial(data: {
+  title: string;
+  content: string;
+  subjectId: number;
+  files?: File[];
+  pdf?: File;
+}) {
+  const fd = new FormData();
+  fd.append("title", data.title);
+  fd.append("content", data.content);
+  fd.append("subjectId", String(data.subjectId));
+  data.files?.forEach((file) => fd.append("files", file));
+  if (data.pdf) fd.append("pdf", data.pdf);
+  return fetchWithFormData("/api/materials/upload", "POST", fd);
+}
+
+// ─── 대형 파일 업로드 (10MB 초과) ───────────────────────────
+
+type RefType = "QUESTION" | "ANSWER" | "PROFILE" | "MATERIAL" | "BOARD";
+
+/** 대형 파일 업로드: init → S3 PUT → complete */
+export async function uploadLargeFile(file: File, refType: RefType) {
+  // Step 1: init
+  const initRes = await fetchAPI("/api/files/init", "POST", {
+    fileName: file.name,
+    contentType: file.type,
+    fileSize: file.size,
+    refType,
+  });
+
+  // Step 2: S3 직접 업로드
+  const s3Res = await fetch(initRes.presignedUrl, {
+    method: "PUT",
+    headers: { "Content-Type": file.type },
+    body: file,
+  });
+  if (!s3Res.ok) throw new Error("S3 업로드 실패");
+
+  // Step 3: complete
+  return fetchAPI(`/api/files/${initRes.fileId}/complete`, "POST");
+}
+
+// ─── 파일 다운로드 / 삭제 ───────────────────────────────────
+
+/** 파일 다운로드 URL 조회 */
+export async function getFileDownloadUrl(
+  fileId: number | string,
+): Promise<string> {
+  const res = await fetchAPI(`/api/files/${fileId}/download`, "GET");
+  return res.downloadUrl;
+}
+
+/** 파일 삭제 */
+export async function deleteFile(fileId: number | string) {
+  return fetchAPI(`/api/files/${fileId}/delete`, "DELETE");
+}

--- a/lib/functions/serverProxyMultipart.ts
+++ b/lib/functions/serverProxyMultipart.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_HOST;
+
+/**
+ * 클라이언트 요청을 백엔드로 그대로 프록시 (multipart / JSON 모두 지원)
+ * - Content-Type(boundary 포함)과 body를 원본 그대로 전달
+ * - Authorization 헤더 자동 전달
+ */
+export async function proxyToBackend(
+  request: NextRequest,
+  backendPath: string,
+  method: string,
+) {
+  const auth = request.headers.get("authorization");
+  const contentType = request.headers.get("content-type");
+  const body = method === "GET" ? undefined : await request.arrayBuffer();
+
+  const headers: Record<string, string> = {};
+  if (auth) headers["Authorization"] = auth;
+  if (contentType) headers["Content-Type"] = contentType;
+
+  const res = await fetch(`${API_BASE_URL}${backendPath}`, {
+    method,
+    headers,
+    body,
+  });
+
+  if (res.status === 204) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}


### PR DESCRIPTION
## 상황 설명
기존의 s3 로직은 orchestration 문제가 3중첩으로 있어 해결이 필요하다고 생각하였습니다.
그렇기에 기존의 프론트에서 filename&type 전달과 preSignedURL+key 반환을 프론트에서 하지 않고, 백엔드에서 통합으로 진행하는 방식으로 변경하였습니다.
## 변경 사항
- **새로 추가된 파일 (9개)**
    - `lib/functions/multipartApi.ts` (multipart 공통 함수)
    - `lib/functions/serverProxyMultipart.ts` (API Route)
    - `app/api/boards/upload/route.ts` (게시글 생성 proxy)
    - `app/api/materials/upload/route.ts`  (학습자료 생성 proxy)
    - `app/api/profile/upload/route.ts` (프로필 수정 proxy)
    - `app/api/files/init/route.ts` (대형 파일 초기화 proxy)
    - `app/api/files/[fileId]/complete/route.ts` (대형 파일 완료 proxy)
    - `app/api/files/[fileId]/download/route.ts` (파일 다운로드 URL proxy)
    - `app/api/files/[fileId]/delete/route.ts` (파일 삭제 proxy)
- **수정된 파일 (4개)**
    - `lib/functions/index.ts` (새 모듈 export 추가)
    - `app/(setting)/editprofile/page.tsx` (프로필 수정  `uploadProfile()` 1회 호출로 교체)
    - `app/(board)/post/page.tsx` (게시글 생성  `uploadBoard()` 1회 호출로 교체)
    - `app/(board)/upload/page.tsx` (학습자료 생성  `uploadMaterial()` 1회 호출로 교체)

개선 전에는 3중첩이였지만, 현재는 대부분 중첩없는 1회 호출로 s3 관련 이미지 API를 사용할 수 있습니다.